### PR TITLE
Fix runtime threading warning about accessing UI in a background thread

### DIFF
--- a/NantesPVB/ViewControllers/HomeViewController.m
+++ b/NantesPVB/ViewControllers/HomeViewController.m
@@ -400,16 +400,18 @@
     [self doneAction];
     
     [(AppDelegate*)[[UIApplication sharedApplication] delegate] showLoadingView:@"Connexion en cours ..."];
-    
-    [self performSelectorInBackground:@selector(connectionPerformed) withObject:nil];
-    
-    
+
+    [self performSelectorInBackground:@selector(connectionPerformed:) withObject:@[[idTextField text], [pwdTextField text]]];
+
+
 }
 
-- (void)connectionPerformed {
-    
+- (void)connectionPerformed:(NSArray*)credentials {
+
     @autoreleasepool {
-        BOOL response = [WSDatas connectionWithId:[idTextField text] andPwd:[pwdTextField text]];
+        NSString *userId = credentials[0];
+        NSString *pwd = credentials[1];
+        BOOL response = [WSDatas connectionWithId: userId andPwd:pwd];
 
         [NSThread sleepForTimeInterval:1.0];
 


### PR DESCRIPTION
Fix threading warning when connecting a user because of textfield text accesses in a background thread